### PR TITLE
Update SQLFluff to v2

### DIFF
--- a/.github/workflows/lint_models.yml
+++ b/.github/workflows/lint_models.yml
@@ -11,6 +11,6 @@ jobs:
         with:
             python-version: "3.8"
       - name: Install SQLFluff
-        run: "pip install sqlfluff~=2.0.0"
+        run: "pip install sqlfluff~=2.1.0"
       - name: Lint models
         run: "sqlfluff lint"

--- a/.github/workflows/lint_models.yml
+++ b/.github/workflows/lint_models.yml
@@ -11,6 +11,6 @@ jobs:
         with:
             python-version: "3.8"
       - name: Install SQLFluff
-        run: "pip install sqlfluff==1.4.5"
+        run: "pip install sqlfluff==~=2.0.0"
       - name: Lint models
         run: "sqlfluff lint"

--- a/.github/workflows/lint_models.yml
+++ b/.github/workflows/lint_models.yml
@@ -11,6 +11,6 @@ jobs:
         with:
             python-version: "3.8"
       - name: Install SQLFluff
-        run: "pip install sqlfluff==~=2.0.0"
+        run: "pip install sqlfluff~=2.0.0"
       - name: Lint models
         run: "sqlfluff lint"

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,7 +1,7 @@
 [sqlfluff]
 dialect = redshift
 templater = jinja
-rules = L001,L002,L003,L004,L005,L006,L007,L008,L009,L010,L011,L012,L013,L014,L015,L017,L018,L019,L020,L021,L022,L023,L024,L025,L027,L030,L033,L036,L037,L039,L040,L041,L042,L045,L046,L047,L048,L049,L050,L051,L053,L054,L055,L058,L059,L060,L061,L063,L065,L066,L067,L071
+rules = AL01,AL02,AL03,AL04,AL05,AL06,AM01,AM02,AM03,AM05,AM06,CP01,CP02,CP03,CP04,CP05,CV01,CV02,CV04,CV05,CV07,CV08,CV11,JJ01,LT01,LT02,LT03,LT04,LT06,LT07,LT08,LT09,LT10,LT11,LT12,LT13,RF02,RF06,ST03,ST04,ST05,ST08
 large_file_skip_byte_limit = 50000
 
 [sqlfluff:templater:jinja]
@@ -10,33 +10,31 @@ library_path = sqlfluff/sqlfluff_libs
 [sqlfluff:templater:jinja:context]
 target = prod
 
+[sqlfluff:indentation]
+tab_space_size = 4
+indent_unit = space
+
 [sqlfluff:layout:type:casting_operator]
 spacing_before = single
 spacing_after = single
 
-[sqlfluff:rules]
-tab_space_size = 4
-indent_unit = space
+[sqlfluff:layout:operators]
 operator_new_lines = after
 
-[sqlfluff:rules:L004]
-indent_unit = space
-tab_space_size = 4
-
-[sqlfluff:rules:L010]
-capitalisation_policy = lower
-
-[sqlfluff:rules:L030]
-extended_capitalisation_policy = lower
-
-[sqlfluff:rules:L042]
-forbid_subquery_in = both
-
-[sqlfluff:rules:L063]
-extended_capitalisation_policy = lower
-
-[sqlfluff:rules:L066]
+[sqlfluff:rules:aliasing.length]
 min_alias_length = 3
 
-[sqlfluff:rules:L067]
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.identifiers]
+capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.types]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:convention.casting_style]
 preferred_type_casting_style = shorthand
+
+[sqlfluff:rules:structure.subquery]
+forbid_subquery_in = both


### PR DESCRIPTION
Upgrade notes can be found here: https://docs.sqlfluff.com/en/stable/releasenotes.html#upgrading-2-0